### PR TITLE
Fix nginx_dissite link creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,7 @@ install:
 	for dir in $(INSTALL_DIRS); do mkdir -p $(DESTDIR)$(PREFIX)/$$dir; done
 	for file in $(INSTALL_FILES); do cp $$file $(DESTDIR)$(PREFIX)/$$file; done
 	mkdir -p $(DESTDIR)$(DOC_DIR)
-	cd $(DESTDIR)$(PREFIX)/bin
-	ln -s nginx_ensite nginx_dissite
-	cd $(CURR_DIR)
+	(cd $(DESTDIR)$(PREFIX)/bin && ln -sf nginx_ensite nginx_dissite)
 	cp -r doc/man/$(DOC_FILES) $(DESTDIR)$(DOC_DIR)/
 	mkdir -p $(COMPLETION_DIR)
 	cp bash_completion.d/* $(COMPLETION_DIR)/


### PR DESCRIPTION
Fix for #12 because at least in my case, `make install` is not doing the `cd /usr/local/bin` and is instead creating a broken link in the current dir.

I also need this to be an idempotent operation.
